### PR TITLE
users/show.html.erbの12~14行目あたりのユーザー名にcssを追加しました。

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,7 +9,9 @@
       <div class="col-12 card shadow mb-5">
         <div class="card-body">
           <div class="mypage-container mt-3 d-flex">
-            <h6>ユーザー名：<%= @user.name %></h6>
+            <h6><span class="user-icon" style="background-color: #007bff; color: white; padding: 5px 20px; border-radius: 5px;font-weight: bold; margin-right: 10px;">ユーザー名</span>
+              <%= @user.name %>
+            </h6>
             <% if current_user && current_user.own?(@user) %>
               <div class="ms-auto">
                 <%= link_to 'ユーザー情報編集', edit_user_registration_path, class:"user-edit-button" %>


### PR DESCRIPTION
##関連issue
Closes #129 
##概要
ユーザーマイページの「ユーザー名：」を「ユーザー名」に変更してボタン風にアイコン設定をcssを使用して追加修正しました。

##実装内容
- 変更点1　users/show.html.erbファイルの12~14行目をcssを直接書き込み追加しました。（users/show.scssに追加しようとしましたが、うまく反映できなかったため直書きしました汗　変更点2でscssにコピペできるようにコードを貼っときます。）
- 変更点2　
.user-icon {
    background-color: #007bff;
    color: white;
    padding: 5px 20px;
    border-radius: 5px;
    font-weight: bold;
    margin-right: 10px;
}

##備考
![スクリーンショット 2024-08-22 141045](https://github.com/user-attachments/assets/4567ca64-853f-470b-97e6-b41cad6dfd19)

